### PR TITLE
Allow external code to manage server start, stop, and accept

### DIFF
--- a/kidgloves.rb
+++ b/kidgloves.rb
@@ -57,53 +57,76 @@ module Rack
         @app = app
         @host = options[:Host] || '0.0.0.0'
         @port = options[:Port] || 8089
+        @server = nil
       end
 
-      def listen
+      # Start a server and go into an infinite accept loop.
+      def listen(&block)
+        start(&block)
+        loop { accept }
+      ensure
+        stop
+      end
+
+      # Start the server but don't go into the accept loop. The #accept method
+      # can then be used to process single connections.
+      def start
         log "Starting server on #{@host}:#{@port}"
-        server = TCPServer.new(@host, @port)
+        @server = TCPServer.new(@host, @port)
+        yield @server if block_given?
+      end
 
-        yield server if block_given?
-
-        loop do
-          socket = server.accept
-          socket.sync = true
-          log "#{socket.peeraddr[2]} (#{socket.peeraddr[3]})"
-          begin
-
-            req = {}
-
-            # parse the request line
-            request = socket.gets
-            method, path, version = request.split(" ")
-            req["REQUEST_METHOD"] = method
-            info, query = path.split("?")
-            req["PATH_INFO"] = info
-            req["QUERY_STRING"] = query
-
-            # parse the headers
-            while (line = socket.gets)
-              line.strip!
-              break if line.size == 0
-              key, val = line.split(": ")
-              key = key.upcase.gsub('-', '_')
-              key = "HTTP_#{key}" if !%w[CONTENT_TYPE CONTENT_LENGTH].include?(key)
-              req[key] = val
-            end
-
-            # parse the body
-            body = ''
-            if (len = req['CONTENT_LENGTH']) && ["POST", "PUT"].member?(method)
-              body = socket.read(len.to_i)
-            end
-
-            # process the request
-            process_request(req, body, socket)
-
-          ensure
-            socket.close if not socket.closed?
-          end
+      # Stop a server started with #start.
+      def stop
+        if @server && !@server.closed?
+          @server.close
+          @server = nil
+          true
         end
+      end
+
+      # Test whether the server is currently running.
+      def running?
+        !@server.nil?
+      end
+
+      # Accept and process a single connection / request. The server must be
+      # running before this method is called.
+      def accept
+        socket = @server.accept
+        socket.sync = true
+        log "#{socket.peeraddr[2]} (#{socket.peeraddr[3]})"
+
+        req = {}
+
+        # parse the request line
+        request = socket.gets
+        method, path, version = request.split(" ")
+        req["REQUEST_METHOD"] = method
+        info, query = path.split("?")
+        req["PATH_INFO"] = info
+        req["QUERY_STRING"] = query
+
+        # parse the headers
+        while (line = socket.gets)
+          line.strip!
+          break if line.size == 0
+          key, val = line.split(": ")
+          key = key.upcase.gsub('-', '_')
+          key = "HTTP_#{key}" if !%w[CONTENT_TYPE CONTENT_LENGTH].include?(key)
+          req[key] = val
+        end
+
+        # parse the body
+        body = ''
+        if (len = req['CONTENT_LENGTH']) && ["POST", "PUT"].member?(method)
+          body = socket.read(len.to_i)
+        end
+
+        # process the request
+        process_request(req, body, socket)
+      ensure
+        socket.close if socket && !socket.closed?
       end
 
       def log(message)


### PR DESCRIPTION
This lets external code manage server startup and when new connections are accepted. The case I have in mind is a set of tests that fork/exec a command that make an HTTP request. I'd like to start a server in the test process, exec the command, accept a single connection, and then check that the command generated the correct output.

Something like:

```
require 'kidgloves'

app = lambda { |env| [200, {}, 'hiya'] }
server = Rack::Handler::KidGloves.new(app, :Host => '127.0.0.1', :Port => 8999)
server.start

10.times do |i|
  rd, wr = IO.pipe
  pid =
    fork do
      rd.close
      STDOUT.reopen(wr)
      STDIN.reopen('/dev/null')
      exec "curl -s http://localhost:8999/"
    end
  wr.close

  server.accept

  output = rd.read
  rd.close
  Process.wait(pid)

  puts "read #{output.inspect} from child process"
end

server.stop
```
